### PR TITLE
feat: make clipboard optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["command-line-utilities", "text-processing"]
 
 [dependencies]
 anstyle = "1.0.7"
-arboard = "3.4"
+arboard = { version = "3.4", optional = true }
 clap = { version = "4.5", features = ["derive", "unicode"] }
 human-panic = "2.0"
 rand = "0.8"
@@ -19,3 +19,6 @@ rand = "0.8"
 [dev-dependencies]
 assert_cmd = "2.0"
 predicates = "3.1"
+
+[features]
+clipboard = ["dep:arboard"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "clipboard")]
 use arboard::Clipboard;
 use clap::Parser;
 
@@ -15,6 +16,7 @@ struct Cli {
     alternate: bool,
 
     /// Copy the modified text to the clipboard.
+    #[cfg(feature = "clipboard")]
     #[arg(short, long, default_value = "false")]
     no_copy: bool,
 }
@@ -31,6 +33,7 @@ fn main() {
 
     println!("{}", output);
 
+    #[cfg(feature = "clipboard")]
     if !args.no_copy {
         match Clipboard::new() {
             Ok(mut clipboard) => {


### PR DESCRIPTION
As mentioned in #14, it would be nice to be able to compile this without `arboard` to have fewer dependencies. This PR entirely removes the clipboard (from the default, it can still be enabled with the clipboard feature) and assumes that any copying will be done by the user.

This could be done by just copying from the terminal emulator, or piping the stdout of the program into something like `wl-copy` or `xclip`

- [ ] Copying is explicitly mentioned in the README, so this should be adjusted.
- [ ] Perhaps we should entirely remove the clipboard dependency (not even optional)?
- [ ] Tests need to be adjusted, as they all have the `--no-copy` argument